### PR TITLE
fix(uploader, files/handlers): fix incorrect unlock, catch and check error after calling api

### DIFF
--- a/src/client/web/src/client/uploader.ts
+++ b/src/client/web/src/client/uploader.ts
@@ -114,7 +114,10 @@ export class FileUploader {
         try {
           uploadStatusResp = await this.uploadStatus(this.filePath);
         } catch (e) {
-          if (uploadStatusResp.status === 500) {
+          if (uploadStatusResp == null) {
+            this.errMsg = `${this.errMsg}; unknown error: empty uploadStatus response`;
+            break;          
+          } else if (uploadStatusResp.status === 500) {
             if (
               !uploadStatusResp.statusText.includes("fail to lock the file") &&
               uploadStatusResp.statusText !== ""

--- a/src/handlers/fileshdr/handlers.go
+++ b/src/handlers/fileshdr/handlers.go
@@ -76,13 +76,16 @@ func (h *FileHandlers) NewAutoLocker(c *gin.Context, key string) *AutoLocker {
 func (lk *AutoLocker) Exec(handler func()) {
 	var err error
 	kv := lk.h.deps.KV()
+	locked := false
 
 	defer func() {
 		if p := recover(); p != nil {
 			fmt.Println(p)
 		}
-		if err = kv.Unlock(lk.key); err != nil {
-			fmt.Println(err)
+		if locked {
+			if err = kv.Unlock(lk.key); err != nil {
+				fmt.Println(err)
+			}
 		}
 	}()
 
@@ -91,6 +94,7 @@ func (lk *AutoLocker) Exec(handler func()) {
 		return
 	}
 
+	locked = true
 	handler()
 }
 

--- a/src/server/server_files_test.go
+++ b/src/server/server_files_test.go
@@ -234,11 +234,11 @@ func TestFileHandlers(t *testing.T) {
 
 	t.Run("test dirs APIs: Mkdir-Create-UploadChunk-List", func(t *testing.T) {
 		for dirPath, files := range map[string]map[string]string{
-			"dir/path1/": map[string]string{
+			"dir/path1": map[string]string{
 				"f1.md": "11111",
 				"f2.md": "22222222222",
 			},
-			"dir/path1/path2": map[string]string{
+			"dir/path2/path2": map[string]string{
 				"f3.md": "3333333",
 			},
 		} {


### PR DESCRIPTION
Please answer following questions before creating the PR:

* What is this PR about?
-  files/handlers: fix incorrect unlock in files handlers
-  uploader: catch and check error after checking upload status
* Is there any test which covers the change?

