### PR TITLE
chore(web client): clean up

### DIFF
--- a/src/client/web/package.json
+++ b/src/client/web/package.json
@@ -15,8 +15,8 @@
     "build:task:dev": "webpack --config webpack.task.dev.js --watch",
     "e2e": "jest -c jest.e2e.config.js",
     "e2e:watch": "jest --watch -c jest.e2e.config.js",
-    "test": "jest test",
-    "test:watch": "jest test --watch",
+    "test": "jest test --maxWorkers=2",
+    "test:watch": "jest test --watch --maxWorkers=2",
     "copy": "cp -r ../../static ../../../dockers/nginx/"
   },
   "author": "hexxa",

--- a/src/client/web/src/common/env.ts
+++ b/src/client/web/src/common/env.ts
@@ -1,0 +1,7 @@
+export function alertMsg(msg: string) {
+  if (alert != null) {
+    alert(msg);
+  } else {
+    console.log(msg);
+  }
+}

--- a/src/client/web/src/components/browser.tsx
+++ b/src/client/web/src/components/browser.tsx
@@ -211,6 +211,25 @@ export class Browser extends React.Component<Props, State, {}> {
     });
   };
 
+  selectAll = () => {
+    let newSelected = Map<string, boolean>();
+    const someSelected = this.state.selectedItems.size === 0 ? true : false;
+    if (someSelected) {
+      this.props.items.forEach((item) => {
+        newSelected = newSelected.set(item.name, true);
+      });
+    } else {
+      this.props.items.forEach((item) => {
+        newSelected = newSelected.delete(item.name);
+      });
+    }
+
+    this.setState({
+      selectedSrc: this.props.dirPath.join("/"),
+      selectedItems: newSelected,
+    });
+  };
+
   render() {
     const breadcrumb = this.props.dirPath.map(
       (pathPart: string, key: number) => {
@@ -434,7 +453,15 @@ export class Browser extends React.Component<Props, State, {}> {
                   <td>Name</td>
                   <td className={sizeCellClass}>File Size</td>
                   <td className={modTimeCellClass}>Mod Time</td>
-                  <td>Edit</td>
+                  <td>
+                    <button
+                      onClick={() => this.selectAll()}
+                      className={`white-font`}
+                      style={{ width: "8rem", display: "inline-block" }}
+                    >
+                      Select All
+                    </button>
+                  </td>
                 </tr>
               </thead>
               <tbody>{itemList}</tbody>

--- a/src/client/web/src/components/browser.tsx
+++ b/src/client/web/src/components/browser.tsx
@@ -4,6 +4,7 @@ import { List, Map } from "immutable";
 import FileSize from "filesize";
 
 import { Layouter } from "./layouter";
+import { updater } from "./browser.updater";
 import { ICoreState } from "./core_state";
 import {
   IUsersClient,
@@ -39,141 +40,10 @@ export interface Props {
   update?: (updater: (prevState: ICoreState) => ICoreState) => void;
 }
 
-function getItemPath(dirPath: string, itemName: string): string {
+export function getItemPath(dirPath: string, itemName: string): string {
   return dirPath.endsWith("/")
     ? `${dirPath}${itemName}`
     : `${dirPath}/${itemName}`;
-}
-
-export class Updater {
-  static props: Props;
-  private static usersClient: IUsersClient;
-  private static filesClient: IFilesClient;
-
-  static init = (props: Props) => (Updater.props = { ...props });
-  static setClients(usersClient: IUsersClient, filesClient: IFilesClient) {
-    Updater.usersClient = usersClient;
-    Updater.filesClient = filesClient;
-  }
-
-  static setUploadings = (infos: Map<string, UploadEntry>) => {
-    Updater.props.uploadings = List<UploadInfo>(
-      infos.valueSeq().map(
-        (v: UploadEntry): UploadInfo => {
-          return {
-            realFilePath: v.filePath,
-            size: v.size,
-            uploaded: v.uploaded,
-          };
-        }
-      )
-    );
-  };
-
-  static setItems = async (dirParts: List<string>): Promise<void> => {
-    const dirPath = dirParts.join("/");
-    const listResp = await Updater.filesClient.list(dirPath);
-
-    Updater.props.dirPath = dirParts;
-    Updater.props.items =
-      listResp.status === 200
-        ? List<MetadataResp>(listResp.data.metadatas)
-        : Updater.props.items;
-  };
-
-  static refreshUploadings = async (): Promise<boolean> => {
-    const luResp = await Updater.filesClient.listUploadings();
-
-    Updater.props.uploadings =
-      luResp.status === 200
-        ? List<UploadInfo>(luResp.data.uploadInfos)
-        : Updater.props.uploadings;
-    return luResp.status === 200;
-  };
-
-  static deleteUploading = async (filePath: string): Promise<boolean> => {
-    UploadMgr.delete(filePath);
-    const resp = await Updater.filesClient.deleteUploading(filePath);
-    return resp.status === 200;
-  };
-
-  static stopUploading = (filePath: string) => {
-    UploadMgr.stop(filePath);
-  };
-
-  static mkDir = async (dirPath: string): Promise<void> => {
-    let resp = await Updater.filesClient.mkdir(dirPath);
-    if (resp.status !== 200) {
-      alert(`failed to make dir ${dirPath}`);
-    }
-  };
-
-  static delete = async (
-    dirParts: List<string>,
-    items: List<MetadataResp>,
-    selectedItems: Map<string, boolean>
-  ): Promise<void> => {
-    const delRequests = items
-      .filter((item) => {
-        return selectedItems.has(item.name);
-      })
-      .map(
-        async (selectedItem: MetadataResp): Promise<string> => {
-          const itemPath = getItemPath(dirParts.join("/"), selectedItem.name);
-          const resp = await Updater.filesClient.delete(itemPath);
-          return resp.status === 200 ? "" : selectedItem.name;
-        }
-      );
-
-    const failedFiles = await Promise.all(delRequests);
-    failedFiles.forEach((failedFile) => {
-      if (failedFile !== "") {
-        alert(`failed to delete ${failedFile}`);
-      }
-    });
-    return Updater.setItems(dirParts);
-  };
-
-  static moveHere = async (
-    srcDir: string,
-    dstDir: string,
-    selectedItems: Map<string, boolean>
-  ): Promise<void> => {
-    const moveRequests = List<string>(selectedItems.keys()).map(
-      async (itemName: string): Promise<string> => {
-        const oldPath = getItemPath(srcDir, itemName);
-        const newPath = getItemPath(dstDir, itemName);
-        const resp = await Updater.filesClient.move(oldPath, newPath);
-        return resp.status === 200 ? "" : itemName;
-      }
-    );
-
-    const failedFiles = await Promise.all(moveRequests);
-    failedFiles.forEach((failedItem) => {
-      if (failedItem !== "") {
-        alert(`failed to move ${failedItem}`);
-      }
-    });
-
-    return Updater.setItems(List<string>(dstDir.split("/")));
-  };
-
-  static addUploadFiles = (fileList: FileList, len: number) => {
-    for (let i = 0; i < len; i++) {
-      const filePath = getItemPath(
-        Updater.props.dirPath.join("/"),
-        fileList[i].name
-      );
-      // do not wait for the promise
-      UploadMgr.add(fileList[i], filePath);
-    }
-    Updater.setUploadings(UploadMgr.list());
-  };
-
-  static setBrowser = (prevState: ICoreState): ICoreState => {
-    prevState.panel.browser = { ...prevState.panel, ...Updater.props };
-    return prevState;
-  };
 }
 
 export interface State {
@@ -190,8 +60,8 @@ export class Browser extends React.Component<Props, State, {}> {
 
   constructor(p: Props) {
     super(p);
-    Updater.init(p);
-    Updater.setClients(new UsersClient(""), new FilesClient(""));
+    updater().init(p);
+    updater().setClients(new UsersClient(""), new FilesClient(""));
     this.update = p.update;
     this.state = {
       inputValue: "",
@@ -210,12 +80,13 @@ export class Browser extends React.Component<Props, State, {}> {
     };
 
     UploadMgr.setStatusCb(this.updateProgress);
-    Updater.setItems(p.dirPath)
+    updater()
+      .setItems(p.dirPath)
       .then(() => {
-        return Updater.refreshUploadings();
+        return updater().refreshUploadings();
       })
       .then((_: boolean) => {
-        this.update(Updater.setBrowser);
+        this.update(updater().setBrowser);
       });
   }
 
@@ -234,52 +105,57 @@ export class Browser extends React.Component<Props, State, {}> {
   };
 
   addUploadFile = (event: React.ChangeEvent<HTMLInputElement>) => {
-    Updater.addUploadFiles(event.target.files, event.target.files.length);
-    this.update(Updater.setBrowser);
+    updater().addUploadFiles(event.target.files, event.target.files.length);
+    this.update(updater().setBrowser);
   };
 
   updateProgress = (infos: Map<string, UploadEntry>) => {
-    Updater.setUploadings(infos);
-    Updater.setItems(this.props.dirPath).then(() => {
-      this.update(Updater.setBrowser);
-    });
+    updater().setUploadings(infos);
+    updater()
+      .setItems(this.props.dirPath)
+      .then(() => {
+        this.update(updater().setBrowser);
+      });
   };
 
   onMkDir = () => {
     if (this.state.inputValue === "") {
       alert("folder name can not be empty");
+      return;
     }
 
     const dirPath = getItemPath(
       this.props.dirPath.join("/"),
       this.state.inputValue
     );
-    Updater.mkDir(dirPath)
+    updater()
+      .mkDir(dirPath)
       .then(() => {
         this.setState({ inputValue: "" });
-        return Updater.setItems(this.props.dirPath);
+        return updater().setItems(this.props.dirPath);
       })
       .then(() => {
-        this.update(Updater.setBrowser);
+        this.update(updater().setBrowser);
       });
   };
 
-  deleteUploading = (filePath: string) => {
-    Updater.deleteUploading(filePath)
+  deleteUploading = (filePath: string): Promise<void> => {
+    return updater()
+      .deleteUploading(filePath)
       .then((ok: boolean) => {
         if (!ok) {
           alert(`Failed to delete uploading ${filePath}`);
         }
-        return Updater.refreshUploadings();
+        return updater().refreshUploadings();
       })
       .then(() => {
-        this.update(Updater.setBrowser);
+        this.update(updater().setBrowser);
       });
   };
 
   stopUploading = (filePath: string) => {
-    Updater.stopUploading(filePath);
-    this.update(Updater.setBrowser);
+    updater().stopUploading(filePath);
+    this.update(updater().setBrowser);
   };
 
   delete = () => {
@@ -292,17 +168,15 @@ export class Browser extends React.Component<Props, State, {}> {
       return;
     }
 
-    Updater.delete(
-      this.props.dirPath,
-      this.props.items,
-      this.state.selectedItems
-    ).then(() => {
-      this.update(Updater.setBrowser);
-      this.setState({
-        selectedSrc: "",
-        selectedItems: Map<string, boolean>(),
+    updater()
+      .delete(this.props.dirPath, this.props.items, this.state.selectedItems)
+      .then(() => {
+        this.update(updater().setBrowser);
+        this.setState({
+          selectedSrc: "",
+          selectedItems: Map<string, boolean>(),
+        });
       });
-    });
   };
 
   gotoChild = (childDirName: string) => {
@@ -314,9 +188,11 @@ export class Browser extends React.Component<Props, State, {}> {
       return;
     }
 
-    Updater.setItems(dirPath).then(() => {
-      this.update(Updater.setBrowser);
-    });
+    updater()
+      .setItems(dirPath)
+      .then(() => {
+        this.update(updater().setBrowser);
+      });
   };
 
   moveHere = () => {
@@ -327,17 +203,19 @@ export class Browser extends React.Component<Props, State, {}> {
       return;
     }
 
-    Updater.moveHere(
-      this.state.selectedSrc,
-      this.props.dirPath.join("/"),
-      this.state.selectedItems
-    ).then(() => {
-      this.update(Updater.setBrowser);
-      this.setState({
-        selectedSrc: "",
-        selectedItems: Map<string, boolean>(),
+    updater()
+      .moveHere(
+        this.state.selectedSrc,
+        this.props.dirPath.join("/"),
+        this.state.selectedItems
+      )
+      .then(() => {
+        this.update(updater().setBrowser);
+        this.setState({
+          selectedSrc: "",
+          selectedItems: Map<string, boolean>(),
+        });
       });
-    });
   };
 
   render() {

--- a/src/client/web/src/components/browser.tsx
+++ b/src/client/web/src/components/browser.tsx
@@ -14,7 +14,7 @@ import {
 } from "../client";
 import { FilesClient } from "../client/files";
 import { UsersClient } from "../client/users";
-import { UploadMgr } from "../worker/upload_mgr";
+import { Up } from "../worker/upload_mgr";
 import { UploadEntry } from "../worker/interface";
 
 export const uploadCheckCycle = 1000;
@@ -79,7 +79,7 @@ export class Browser extends React.Component<Props, State, {}> {
       uploadInput.click();
     };
 
-    UploadMgr.setStatusCb(this.updateProgress);
+    Up().setStatusCb(this.updateProgress);
     updater()
       .setItems(p.dirPath)
       .then(() => {

--- a/src/client/web/src/components/browser.updater.ts
+++ b/src/client/web/src/components/browser.updater.ts
@@ -1,0 +1,150 @@
+import { List, Map } from "immutable";
+
+import { ICoreState } from "./core_state";
+import { Props, getItemPath } from "./browser";
+import {
+  IUsersClient,
+  IFilesClient,
+  MetadataResp,
+  UploadInfo,
+} from "../client";
+import { FilesClient } from "../client/files";
+import { UsersClient } from "../client/users";
+import { UploadEntry } from "../worker/interface";
+import { UploadMgr } from "../worker/upload_mgr";
+
+export class Updater {
+  props: Props;
+  private usersClient: IUsersClient = new UsersClient("");
+  private filesClient: IFilesClient = new FilesClient("");
+
+  init = (props: Props) => (this.props = { ...props });
+  setClients(usersClient: IUsersClient, filesClient: IFilesClient) {
+    this.usersClient = usersClient;
+    this.filesClient = filesClient;
+  }
+
+  addUploadFiles = (fileList: FileList, len: number) => {
+    for (let i = 0; i < len; i++) {
+      const filePath = getItemPath(
+        this.props.dirPath.join("/"),
+        fileList[i].name
+      );
+      // do not wait for the promise
+      UploadMgr.add(fileList[i], filePath);
+    }
+    this.setUploadings(UploadMgr.list());
+  };
+
+  deleteUploading = async (filePath: string): Promise<boolean> => {
+    UploadMgr.delete(filePath);
+    const resp = await this.filesClient.deleteUploading(filePath);
+    return resp.status === 200;
+  };
+
+  setUploadings = (infos: Map<string, UploadEntry>) => {
+    this.props.uploadings = List<UploadInfo>(
+      infos.valueSeq().map(
+        (v: UploadEntry): UploadInfo => {
+          return {
+            realFilePath: v.filePath,
+            size: v.size,
+            uploaded: v.uploaded,
+          };
+        }
+      )
+    );
+  };
+
+  refreshUploadings = async (): Promise<boolean> => {
+    const luResp = await this.filesClient.listUploadings();
+
+    this.props.uploadings =
+      luResp.status === 200
+        ? List<UploadInfo>(luResp.data.uploadInfos)
+        : this.props.uploadings;
+    return luResp.status === 200;
+  };
+
+  stopUploading = (filePath: string) => {
+    UploadMgr.stop(filePath);
+  };
+
+  mkDir = async (dirPath: string): Promise<void> => {
+    const resp = await this.filesClient.mkdir(dirPath);
+    if (resp.status !== 200) {
+      alert(`failed to make dir ${dirPath}`);
+    }
+  };
+
+  delete = async (
+    dirParts: List<string>,
+    items: List<MetadataResp>,
+    selectedItems: Map<string, boolean>
+  ): Promise<void> => {
+    const delRequests = items
+      .filter((item) => {
+        return selectedItems.has(item.name);
+      })
+      .map(
+        async (selectedItem: MetadataResp): Promise<string> => {
+          const itemPath = getItemPath(dirParts.join("/"), selectedItem.name);
+          const resp = await this.filesClient.delete(itemPath);
+          return resp.status === 200 ? "" : selectedItem.name;
+        }
+      );
+
+    const failedFiles = await Promise.all(delRequests);
+    failedFiles.forEach((failedFile) => {
+      if (failedFile !== "") {
+        alert(`failed to delete ${failedFile}`);
+      }
+    });
+    return this.setItems(dirParts);
+  };
+
+  setItems = async (dirParts: List<string>): Promise<void> => {
+    const dirPath = dirParts.join("/");
+    const listResp = await this.filesClient.list(dirPath);
+
+    this.props.dirPath = dirParts;
+    this.props.items =
+      listResp.status === 200
+        ? List<MetadataResp>(listResp.data.metadatas)
+        : this.props.items;
+  };
+
+  moveHere = async (
+    srcDir: string,
+    dstDir: string,
+    selectedItems: Map<string, boolean>
+  ): Promise<void> => {
+    const moveRequests = List<string>(selectedItems.keys()).map(
+      async (itemName: string): Promise<string> => {
+        const oldPath = getItemPath(srcDir, itemName);
+        const newPath = getItemPath(dstDir, itemName);
+        const resp = await this.filesClient.move(oldPath, newPath);
+        return resp.status === 200 ? "" : itemName;
+      }
+    );
+
+    const failedFiles = await Promise.all(moveRequests);
+    failedFiles.forEach((failedItem) => {
+      if (failedItem !== "") {
+        alert(`failed to move ${failedItem}`);
+      }
+    });
+
+    return this.setItems(List<string>(dstDir.split("/")));
+  };
+
+  setBrowser = (prevState: ICoreState): ICoreState => {
+    prevState.panel.browser = { ...prevState.panel, ...this.props };
+    return prevState;
+  };
+}
+
+export const browserUpdater = new Updater();
+export const updater = (): Updater => {
+  return browserUpdater;
+};

--- a/src/client/web/src/components/browser.updater.ts
+++ b/src/client/web/src/components/browser.updater.ts
@@ -24,19 +24,19 @@ export class Updater {
     this.filesClient = filesClient;
   }
 
-  addUploadFiles = (fileList: FileList, len: number) => {
-    for (let i = 0; i < len; i++) {
+  addUploads = (fileList: List<File>) => {
+    fileList.forEach(file => {
       const filePath = getItemPath(
         this.props.dirPath.join("/"),
-        fileList[i].name
+        file.name
       );
       // do not wait for the promise
-      Up().add(fileList[i], filePath);
-    }
+      Up().add(file, filePath);
+    })
     this.setUploadings(Up().list());
   };
 
-  deleteUploading = async (filePath: string): Promise<boolean> => {
+  deleteUpload = async (filePath: string): Promise<boolean> => {
     Up().delete(filePath);
     const resp = await this.filesClient.deleteUploading(filePath);
     return resp.status === 200;
@@ -144,7 +144,10 @@ export class Updater {
   };
 }
 
-export const browserUpdater = new Updater();
+export let browserUpdater = new Updater();
 export const updater = (): Updater => {
   return browserUpdater;
+};
+export const setUpdater = (updater: Updater) => {
+  browserUpdater = updater;
 };

--- a/src/client/web/src/components/browser.updater.ts
+++ b/src/client/web/src/components/browser.updater.ts
@@ -11,7 +11,7 @@ import {
 import { FilesClient } from "../client/files";
 import { UsersClient } from "../client/users";
 import { UploadEntry } from "../worker/interface";
-import { UploadMgr } from "../worker/upload_mgr";
+import { Up } from "../worker/upload_mgr";
 
 export class Updater {
   props: Props;
@@ -31,13 +31,13 @@ export class Updater {
         fileList[i].name
       );
       // do not wait for the promise
-      UploadMgr.add(fileList[i], filePath);
+      Up().add(fileList[i], filePath);
     }
-    this.setUploadings(UploadMgr.list());
+    this.setUploadings(Up().list());
   };
 
   deleteUploading = async (filePath: string): Promise<boolean> => {
-    UploadMgr.delete(filePath);
+    Up().delete(filePath);
     const resp = await this.filesClient.deleteUploading(filePath);
     return resp.status === 200;
   };
@@ -67,7 +67,7 @@ export class Updater {
   };
 
   stopUploading = (filePath: string) => {
-    UploadMgr.stop(filePath);
+    Up().stop(filePath);
   };
 
   mkDir = async (dirPath: string): Promise<void> => {

--- a/src/client/web/src/components/core_state.ts
+++ b/src/client/web/src/components/core_state.ts
@@ -2,11 +2,15 @@ import { List, Set } from "immutable";
 
 import BgWorker from "../worker/upload.bg.worker";
 import { FgWorker } from "../worker/upload.fgworker";
+import { FilesClient } from "../client/files";
+import { UsersClient } from "../client/users";
 
 import { Props as PanelProps } from "./root_frame";
 import { Item } from "./browser";
 import { UploadInfo } from "../client";
 import { Up, initUploadMgr, IWorker } from "../worker/upload_mgr";
+
+import { updater as BrowserUpdater } from "./browser.updater";
 
 export class BaseUpdater {
   public static props: any;
@@ -36,7 +40,23 @@ export function init(): ICoreState {
   const worker = Worker == null ? new FgWorker() : new BgWorker();
   initUploadMgr(worker);
 
-  return initState();
+  const state = initState();
+  InitUpdaters(state);
+  return state;
+}
+
+export function InitUpdaters(state: ICoreState) {
+  BrowserUpdater().init(state.panel.browser);
+  BrowserUpdater().setClients(new UsersClient(""), new FilesClient(""));
+  BrowserUpdater()
+    .setItems(state.panel.browser.dirPath)
+    .then(() => {
+      return BrowserUpdater().refreshUploadings();
+    })
+    .then((_: boolean) => {
+      this.update(BrowserUpdater().setBrowser);
+    });
+
 }
 
 export function isVertical(): boolean {

--- a/src/client/web/src/components/core_state.ts
+++ b/src/client/web/src/components/core_state.ts
@@ -2,15 +2,11 @@ import { List, Set } from "immutable";
 
 import BgWorker from "../worker/upload.bg.worker";
 import { FgWorker } from "../worker/upload.fgworker";
-import { FilesClient } from "../client/files";
-import { UsersClient } from "../client/users";
 
 import { Props as PanelProps } from "./root_frame";
 import { Item } from "./browser";
 import { UploadInfo } from "../client";
 import { Up, initUploadMgr, IWorker } from "../worker/upload_mgr";
-
-import { updater as BrowserUpdater } from "./browser.updater";
 
 export class BaseUpdater {
   public static props: any;
@@ -40,23 +36,7 @@ export function init(): ICoreState {
   const worker = Worker == null ? new FgWorker() : new BgWorker();
   initUploadMgr(worker);
 
-  const state = initState();
-  InitUpdaters(state);
-  return state;
-}
-
-export function InitUpdaters(state: ICoreState) {
-  BrowserUpdater().init(state.panel.browser);
-  BrowserUpdater().setClients(new UsersClient(""), new FilesClient(""));
-  BrowserUpdater()
-    .setItems(state.panel.browser.dirPath)
-    .then(() => {
-      return BrowserUpdater().refreshUploadings();
-    })
-    .then((_: boolean) => {
-      this.update(BrowserUpdater().setBrowser);
-    });
-
+  return initState();
 }
 
 export function isVertical(): boolean {

--- a/src/client/web/src/components/core_state.ts
+++ b/src/client/web/src/components/core_state.ts
@@ -6,7 +6,7 @@ import { FgWorker } from "../worker/upload.fgworker";
 import { Props as PanelProps } from "./root_frame";
 import { Item } from "./browser";
 import { UploadInfo } from "../client";
-import { UploadMgr, IWorker } from "../worker/upload_mgr";
+import { Up, initUploadMgr, IWorker } from "../worker/upload_mgr";
 
 export class BaseUpdater {
   public static props: any;
@@ -27,15 +27,15 @@ export interface ICoreState {
 }
 
 export function initWithWorker(worker: IWorker): ICoreState {
-  UploadMgr.init(worker);
+  initUploadMgr(worker);
   return initState();
 }
 
 export function init(): ICoreState {
   const scripts = Array.from(document.querySelectorAll("script"));
   const worker = Worker == null ? new FgWorker() : new BgWorker();
+  initUploadMgr(worker);
 
-  UploadMgr.init(worker);
   return initState();
 }
 

--- a/src/client/web/src/components/pane_login.tsx
+++ b/src/client/web/src/components/pane_login.tsx
@@ -5,7 +5,7 @@ import { ICoreState } from "./core_state";
 import { IUsersClient } from "../client";
 import { UsersClient } from "../client/users";
 import { Updater as PanesUpdater } from "./panes";
-import { Updater as BrowserUpdater } from "./browser";
+import { updater as BrowserUpdater } from "./browser.updater";
 import { Layouter } from "./layouter";
 
 export interface Props {
@@ -104,7 +104,7 @@ export class AuthPane extends React.Component<Props, State, {}> {
           this.update(PanesUpdater.updateState);
 
           // refresh
-          return BrowserUpdater.setItems(
+          return BrowserUpdater().setItems(
             List<string>(["."])
           );
         } else {
@@ -113,10 +113,10 @@ export class AuthPane extends React.Component<Props, State, {}> {
         }
       })
       .then(() => {
-        return BrowserUpdater.refreshUploadings();
+        return BrowserUpdater().refreshUploadings();
       })
       .then((_: boolean) => {
-        this.update(BrowserUpdater.setBrowser);
+        this.update(BrowserUpdater().setBrowser);
       });
   };
 

--- a/src/client/web/src/components/state_mgr.tsx
+++ b/src/client/web/src/components/state_mgr.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 
+import { updater as BrowserUpdater } from "./browser.updater";
 import { ICoreState, init } from "./core_state";
 import { RootFrame } from "./root_frame";
+import { FilesClient } from "../client/files";
+import { UsersClient } from "../client/users";
 
 export interface Props {}
 export interface State extends ICoreState {}
@@ -10,7 +13,21 @@ export class StateMgr extends React.Component<Props, State, {}> {
   constructor(p: Props) {
     super(p);
     this.state = init();
+    this.initUpdaters(this.state);
   }
+
+  initUpdaters = (state: ICoreState) => {
+    BrowserUpdater().init(state.panel.browser);
+    BrowserUpdater().setClients(new UsersClient(""), new FilesClient(""));
+    BrowserUpdater()
+      .setItems(state.panel.browser.dirPath)
+      .then(() => {
+        return BrowserUpdater().refreshUploadings();
+      })
+      .then((_: boolean) => {
+        this.update(BrowserUpdater().setBrowser);
+      });
+  };
 
   update = (apply: (prevState: ICoreState) => ICoreState): void => {
     this.setState(apply(this.state));

--- a/src/client/web/src/test/helpers.ts
+++ b/src/client/web/src/test/helpers.ts
@@ -1,5 +1,6 @@
 import { Response } from "../client";
-import { ICoreState } from "../components/core_state";
+import { ICoreState, mockState } from "../components/core_state";
+import { List } from "immutable";
 
 export const makePromise = (ret: any): Promise<any> => {
   return new Promise<any>((resolve) => {
@@ -15,4 +16,25 @@ export const makeNumberResponse = (status: number): Promise<Response> => {
   });
 };
 
-export const mockUpdate = (apply: (prevState: ICoreState) => ICoreState): void => {};
+export const mockUpdate = (
+  apply: (prevState: ICoreState) => ICoreState
+): void => {
+  apply(mockState());
+};
+
+export const addMockUpdate = (subState: any) => {
+  subState.update = mockUpdate;
+};
+
+export function mockRandFile(filePath: string): File {
+  const values = new Array<string>(Math.floor(7 * Math.random()));
+  const content = [values.join("")];
+  return new File(content, filePath);
+}
+
+export function mockFileList(filePaths: Array<string>): List<File> {
+  const files = filePaths.map(filePath => {
+    return mockRandFile(filePath);
+  })
+  return List<File>(files);
+}

--- a/src/client/web/src/worker/__test__/upload_mgr.test.ts
+++ b/src/client/web/src/worker/__test__/upload_mgr.test.ts
@@ -4,7 +4,7 @@ import { mock, instance, when, anything } from "ts-mockito";
 import { FilesClient } from "../../client/files_mock";
 import { makePromise } from "../../test/helpers";
 
-import { UploadMgr } from "../upload_mgr";
+import { Up, initUploadMgr } from "../upload_mgr";
 
 import {
   FileWorkerReq,
@@ -115,17 +115,18 @@ describe("UploadMgr", () => {
     ];
 
     const worker = new MockWorker();
-    UploadMgr.setCycle(100);
-
     for (let i = 0; i < tcs.length; i++) {
-      const infoMap = arraytoMap(tcs[i].inputInfos);
-      UploadMgr._setInfos(infoMap);
+      initUploadMgr(worker);
+      const up = Up();
+      up.setCycle(100);
 
-      UploadMgr.init(worker);
+      const infoMap = arraytoMap(tcs[i].inputInfos);
+      up._setInfos(infoMap);
+
       // polling needs several rounds to finish all the tasks
-      await delay(tcs.length * UploadMgr.getCycle() + 1000);
+      await delay(tcs.length * up.getCycle() + 1000);
       // TODO: find a better way to wait
-      const gotInfos = UploadMgr.list();
+      const gotInfos = up.list();
 
       const expectedInfoMap = arraytoMap(tcs[i].expectedInfos);
       gotInfos.keySeq().forEach((filePath) => {
@@ -135,7 +136,7 @@ describe("UploadMgr", () => {
         expect(expectedInfoMap.get(filePath)).toEqual(gotInfos.get(filePath));
       });
 
-      UploadMgr.destory();
+      up.destory();
     }
   });
 });

--- a/src/client/web/src/worker/upload_mgr.ts
+++ b/src/client/web/src/worker/upload_mgr.ts
@@ -88,7 +88,6 @@ export class UploadMgr {
         ...entry,
         runnable: false,
       });
-      console.log("stopped", filePath);
     } else {
       alert(`failed to stop uploading ${filePath}: not found`);
     }
@@ -153,6 +152,6 @@ export const initUploadMgr = (worker: IWorker): UploadMgr => {
 export const Up = (): UploadMgr => {
   return uploadMgr;
 };
-export const FgUp = (): UploadMgr => {
-  return new UploadMgr(new FgWorker());
+export const setUploadMgr = (up: UploadMgr) => {
+  uploadMgr = up;
 };


### PR DESCRIPTION
Please answer following questions before creating the PR:

* What is this PR about?
    - fix(client/web): move browser updater to single file
    - fix(client/web): make UploadMgr singleton
    - test(client/web): add unit tests for browser
    - fix(client/web): updater init should be in StateMgr
    - feat(client/browser): add selectAll butto
* Is there any test which covers the change?
    - unit tests
