### PR TITLE
feat: enable short sharing url

### DIFF
--- a/public/static/css/white.css
+++ b/public/static/css/white.css
@@ -194,7 +194,7 @@
   font-size: 1.4rem;
   line-height: 2rem;
   display: block;
-  overflow-wrap: break-word;
+  word-break: break-all;
 }
 
 .theme-default #item-rows .hr {

--- a/src/client/files.go
+++ b/src/client/files.go
@@ -190,6 +190,7 @@ func (cl *FilesClient) IsSharing(dirpath string) (*http.Response, string, []erro
 		End()
 }
 
+// Deprecated: use ListSharingIDs intead
 func (cl *FilesClient) ListSharings() (*http.Response, *fileshdr.SharingResp, []error) {
 	resp, body, errs := cl.r.Get(cl.url("/v1/fs/sharings")).
 		AddCookie(cl.token).
@@ -206,6 +207,22 @@ func (cl *FilesClient) ListSharings() (*http.Response, *fileshdr.SharingResp, []
 	return resp, shResp, nil
 }
 
+func (cl *FilesClient) ListSharingIDs() (*http.Response, *fileshdr.SharingIDsResp, []error) {
+	resp, body, errs := cl.r.Get(cl.url("/v1/fs/sharings/ids")).
+		AddCookie(cl.token).
+		End()
+	if len(errs) > 0 {
+		return nil, nil, errs
+	}
+
+	shResp := &fileshdr.SharingIDsResp{}
+	err := json.Unmarshal([]byte(body), shResp)
+	if err != nil {
+		return nil, nil, append(errs, err)
+	}
+	return resp, shResp, nil
+}
+
 func (cl *FilesClient) GenerateHash(filepath string) (*http.Response, string, []error) {
 	return cl.r.Post(cl.url("/v1/fs/hashes/sha1")).
 		AddCookie(cl.token).
@@ -213,4 +230,21 @@ func (cl *FilesClient) GenerateHash(filepath string) (*http.Response, string, []
 			FilePath: filepath,
 		}).
 		End()
+}
+
+func (cl *FilesClient) GetSharingDir(shareID string) (*http.Response, string, []error) {
+	resp, body, errs := cl.r.Get(cl.url("/v1/fs/sharings/dirs")).
+		AddCookie(cl.token).
+		Param(fileshdr.ShareIDQuery, shareID).
+		End()
+	if len(errs) > 0 {
+		return nil, "", errs
+	}
+
+	sdResp := &fileshdr.GetSharingDirResp{}
+	err := json.Unmarshal([]byte(body), sdResp)
+	if err != nil {
+		return nil, "", append(errs, err)
+	}
+	return resp, sdResp.SharingDir, nil
 }

--- a/src/client/web/src/client/files.ts
+++ b/src/client/web/src/client/files.ts
@@ -7,10 +7,12 @@ import {
   ListUploadingsResp,
   ListSharingsResp,
   ListSharingIDsResp,
+  GetSharingDirResp,
 } from "./";
 
 const filePathQuery = "fp";
 const listDirQuery = "dp";
+const shareIDQuery = "sh";
 // TODO: get timeout from server
 
 function translateResp(resp: Response<any>): Response<any> {
@@ -205,6 +207,16 @@ export class FilesClient extends BaseClient {
     return this.do({
       method: "get",
       url: `${this.url}/v1/fs/sharings/ids`,
+    });
+  };
+
+  getSharingDir = (shareID: string): Promise<Response<GetSharingDirResp>> => {
+    return this.do({
+      method: "get",
+      url: `${this.url}/v1/fs/sharings/dirs`,
+      params: {
+        [shareIDQuery]: shareID,
+      },
     });
   };
 

--- a/src/client/web/src/client/files.ts
+++ b/src/client/web/src/client/files.ts
@@ -6,6 +6,7 @@ import {
   ListResp,
   ListUploadingsResp,
   ListSharingsResp,
+  ListSharingIDsResp,
 } from "./";
 
 const filePathQuery = "fp";
@@ -197,6 +198,13 @@ export class FilesClient extends BaseClient {
     return this.do({
       method: "get",
       url: `${this.url}/v1/fs/sharings`,
+    });
+  };
+
+  listSharingIDs = (): Promise<Response<ListSharingIDsResp>> => {
+    return this.do({
+      method: "get",
+      url: `${this.url}/v1/fs/sharings/ids`,
     });
   };
 

--- a/src/client/web/src/client/files_mock.ts
+++ b/src/client/web/src/client/files_mock.ts
@@ -5,6 +5,7 @@ import {
   ListUploadingsResp,
   ListSharingsResp,
   ListSharingIDsResp,
+  GetSharingDirResp,
 } from "./";
 
 export interface FilesClientResps {
@@ -26,6 +27,7 @@ export interface FilesClientResps {
   deleteSharingMockResp?: Response;
   listSharingsMockResp?: Response<ListSharingsResp>;
   listSharingIDsMockResp?: Response<ListSharingIDsResp>;
+  getSharingDirMockResp?: Response<GetSharingDirResp>;
   isSharingMockResp?: Response;
   generateHashMockResp?: Response;
   downloadMockResp: Response;
@@ -144,6 +146,13 @@ export const resps = {
       IDs: sharingIDs,
     },
   },
+  getSharingDirMockResp: {
+    status: 200,
+    statusText: "",
+    data: {
+      sharingDir: "/admin/sharing",
+    },
+  },
   isSharingMockResp: { status: 200, statusText: "", data: {} },
   generateHashMockResp: { status: 200, statusText: "", data: {} },
   downloadMockResp: {
@@ -231,9 +240,14 @@ export class MockFilesClient {
   listSharings = (): Promise<Response<ListSharingsResp>> => {
     return this.wrapPromise(this.resps.listSharingsMockResp);
   };
+
   listSharingIDs = (): Promise<Response<ListSharingIDsResp>> => {
     return this.wrapPromise(this.resps.listSharingIDsMockResp);
   };
+
+  getSharingDir = (): Promise<Response<GetSharingDirResp>> => {
+    return this.wrapPromise(this.resps.getSharingDirMockResp);
+  }
 
   isSharing = (dirPath: string): Promise<Response> => {
     return this.wrapPromise(this.resps.isSharingMockResp);

--- a/src/client/web/src/client/files_mock.ts
+++ b/src/client/web/src/client/files_mock.ts
@@ -4,6 +4,7 @@ import {
   ListResp,
   ListUploadingsResp,
   ListSharingsResp,
+  ListSharingIDsResp,
 } from "./";
 
 export interface FilesClientResps {
@@ -24,10 +25,15 @@ export interface FilesClientResps {
   addSharingMockResp?: Response;
   deleteSharingMockResp?: Response;
   listSharingsMockResp?: Response<ListSharingsResp>;
+  listSharingIDsMockResp?: Response<ListSharingIDsResp>;
   isSharingMockResp?: Response;
   generateHashMockResp?: Response;
   downloadMockResp: Response;
 }
+
+const sharingIDs = new Map<string, string>();
+sharingIDs.set("/admin/f1", "e123456");
+sharingIDs.set("/admin/f1", "f123456");
 
 export const resps = {
   createMockResp: { status: 200, statusText: "", data: {} },
@@ -131,6 +137,13 @@ export const resps = {
       sharingDirs: ["mock_sharingfolder1", "mock_sharingfolder2"],
     },
   },
+  listSharingIDsMockResp: {
+    status: 200,
+    statusText: "",
+    data: {
+      IDs: sharingIDs,
+    },
+  },
   isSharingMockResp: { status: 200, statusText: "", data: {} },
   generateHashMockResp: { status: 200, statusText: "", data: {} },
   downloadMockResp: {
@@ -217,6 +230,9 @@ export class MockFilesClient {
 
   listSharings = (): Promise<Response<ListSharingsResp>> => {
     return this.wrapPromise(this.resps.listSharingsMockResp);
+  };
+  listSharingIDs = (): Promise<Response<ListSharingIDsResp>> => {
+    return this.wrapPromise(this.resps.listSharingIDsMockResp);
   };
 
   isSharing = (dirPath: string): Promise<Response> => {

--- a/src/client/web/src/client/index.ts
+++ b/src/client/web/src/client/index.ts
@@ -80,6 +80,10 @@ export interface ListSharingsResp {
   sharingDirs: string[];
 }
 
+export interface ListSharingIDsResp {
+  IDs: Map<string, string>;
+}
+
 export interface ClientConfigMsg {
   clientCfg: ClientConfig;
 }
@@ -137,6 +141,7 @@ export interface IFilesClient {
   deleteSharing: (dirPath: string) => Promise<Response>;
   isSharing: (dirPath: string) => Promise<Response>;
   listSharings: () => Promise<Response<ListSharingsResp>>;
+  listSharingIDs: () => Promise<Response<ListSharingIDsResp>>;
   generateHash: (filePath: string) => Promise<Response>;
   download: (url: string) => Promise<Response>;
 }

--- a/src/client/web/src/client/index.ts
+++ b/src/client/web/src/client/index.ts
@@ -84,6 +84,10 @@ export interface ListSharingIDsResp {
   IDs: Map<string, string>;
 }
 
+export interface GetSharingDirResp {
+  sharingDir: string;
+}
+
 export interface ClientConfigMsg {
   clientCfg: ClientConfig;
 }
@@ -142,6 +146,7 @@ export interface IFilesClient {
   isSharing: (dirPath: string) => Promise<Response>;
   listSharings: () => Promise<Response<ListSharingsResp>>;
   listSharingIDs: () => Promise<Response<ListSharingIDsResp>>;
+  getSharingDir: (shareID: string) => Promise<Response<GetSharingDirResp>>;
   generateHash: (filePath: string) => Promise<Response>;
   download: (url: string) => Promise<Response>;
 }

--- a/src/client/web/src/components/__test__/pane_login.test.tsx
+++ b/src/client/web/src/components/__test__/pane_login.test.tsx
@@ -47,7 +47,7 @@ describe("Login", () => {
     expect(coreState.filesInfo.dirPath.join("/")).toEqual("mock_home/files");
     expect(coreState.filesInfo.isSharing).toEqual(true);
     expect(coreState.sharingsInfo.sharings).toEqual(
-      List(filesResps.listSharingsMockResp.data.sharingDirs)
+      Map(filesResps.listSharingIDsMockResp.data.IDs.entries())
     );
     expect(coreState.uploadingsInfo.uploadings).toEqual(
       List<UploadEntry>(

--- a/src/client/web/src/components/__test__/panel_files.test.tsx
+++ b/src/client/web/src/components/__test__/panel_files.test.tsx
@@ -1,4 +1,5 @@
 import { List } from "immutable";
+import * as immutable from "immutable";
 
 import { initMockWorker } from "../../test/helpers";
 import { FilesPanel } from "../panel_files";
@@ -53,25 +54,27 @@ describe("FilesPanel", () => {
     const { filesPanel, usersCl, filesCl } = initFilesPanel();
 
     const newSharingPath = List(["newPos", "subFolder"]);
-    const sharingDirs = [newSharingPath.join("/")];
+    const sharingDir = newSharingPath.join("/");
+    const newSharings = immutable.Map<string, string>({
+      [sharingDir]: "f123456",
+    });
+    const newSharingsResp = new Map<string, string>();
+    newSharingsResp.set(sharingDir, "f123456");
 
     filesCl.setMock({
       ...filesResps,
-      listSharingsMockResp: {
+      listSharingIDsMockResp: {
         status: 200,
         statusText: "",
         data: {
-          sharingDirs: sharingDirs,
+          IDs: newSharingsResp,
         },
       },
     });
 
     await filesPanel.addSharing(newSharingPath);
 
-
     expect(updater().props.filesInfo.isSharing).toEqual(true);
-    expect(updater().props.sharingsInfo.sharings).toEqual(
-      List(sharingDirs)
-    );
+    expect(updater().props.sharingsInfo.sharings).toEqual(newSharings);
   });
 });

--- a/src/client/web/src/components/__test__/panel_sharings.test.tsx
+++ b/src/client/web/src/components/__test__/panel_sharings.test.tsx
@@ -1,5 +1,5 @@
 import { mock, instance, verify, when, anything } from "ts-mockito";
-import { List } from "immutable";
+import { List, Map } from "immutable";
 
 import { SharingsPanel } from "../panel_sharings";
 import { initUploadMgr } from "../../worker/upload_mgr";
@@ -42,15 +42,19 @@ describe("SharingsPanel", () => {
   test("delete sharing", async () => {
     const { sharingsPanel, usersCl, filesCl } = initSharingsPanel();
 
-    const newSharings = ["mock_sharingfolder1", "mock_sharingfolder2"];
+    const newSharings = Map<string, string>({
+      "mock_sharingfolder1": "f123456",
+      "mock_sharingfolder2": "f123456",
+    })
 
     filesCl.setMock({
       ...filesResps,
-      listSharingsMockResp: {
+      listSharingIDsMockResp: {
         status: 200,
         statusText: "",
         data: {
-          sharingDirs: newSharings,
+          // it seems immutable map will be converted into built-in map automatically
+          IDs: newSharings, 
         },
       },
     });
@@ -59,6 +63,6 @@ describe("SharingsPanel", () => {
 
     // TODO: check delSharing's input
     expect(updater().props.filesInfo.isSharing).toEqual(false);
-    expect(updater().props.sharingsInfo.sharings).toEqual(List(newSharings));
+    expect(updater().props.sharingsInfo.sharings).toEqual(newSharings);
   });
 });

--- a/src/client/web/src/components/__test__/state_mgr.test.tsx
+++ b/src/client/web/src/components/__test__/state_mgr.test.tsx
@@ -44,7 +44,7 @@ describe("State Manager", () => {
     expect(coreState.filesInfo.dirPath.join("/")).toEqual("mock_home/files");
     expect(coreState.filesInfo.isSharing).toEqual(true);
     expect(coreState.sharingsInfo.sharings).toEqual(
-      List(filesResps.listSharingsMockResp.data.sharingDirs)
+      Map(filesResps.listSharingIDsMockResp.data.IDs.entries())
     );
     expect(coreState.uploadingsInfo.uploadings).toEqual(
       List<UploadEntry>(
@@ -180,7 +180,7 @@ describe("State Manager", () => {
     expect(coreState.filesInfo.items).toEqual(
       List(filesResps.listHomeMockResp.data.metadatas)
     );
-    expect(coreState.sharingsInfo.sharings).toEqual(List([]));
+    expect(coreState.sharingsInfo.sharings).toEqual(Map<string, string>());
     expect(coreState.uploadingsInfo.uploadings).toEqual(List<UploadEntry>([]));
 
     // login

--- a/src/client/web/src/components/__test__/topbar.test.tsx
+++ b/src/client/web/src/components/__test__/topbar.test.tsx
@@ -93,7 +93,7 @@ describe("TopBar", () => {
     );
     expect(coreState.filesInfo.isSharing).toEqual(false);
     expect(coreState.filesInfo.items).toEqual(List());
-    expect(coreState.sharingsInfo.sharings).toEqual(List());
+    expect(coreState.sharingsInfo.sharings).toEqual(Map<string, string>());
     expect(coreState.uploadingsInfo.uploadings).toEqual(List<UploadEntry>());
 
     // login

--- a/src/client/web/src/components/core_state.ts
+++ b/src/client/web/src/components/core_state.ts
@@ -64,7 +64,7 @@ export function initState(): ICoreState {
       uploadFiles: List<File>([]),
     },
     sharingsInfo: {
-      sharings: List<string>([]),
+      sharings: Map<string, string>(),
     },
     admin: {
       users: Map<string, User>(),

--- a/src/client/web/src/components/layout/rows.tsx
+++ b/src/client/web/src/components/layout/rows.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { List, Map, Set } from "immutable";
+import { List } from "immutable";
 
-import { RiArrowUpDownFill } from "@react-icons/all-files/ri/RiArrowUpDownFill";
+import { BiSortUp } from "@react-icons/all-files/bi/BiSortUp";
+
 
 import { Flexbox } from "./flexbox";
 
@@ -103,7 +104,7 @@ export class Rows extends React.Component<Props, State, {}> {
         <div className="margin-b-l">
           <Flexbox
             children={List([
-              <RiArrowUpDownFill
+              <BiSortUp
                 size="3rem"
                 className="black-font margin-r-m"
               />,

--- a/src/client/web/src/components/panel_files.tsx
+++ b/src/client/web/src/components/panel_files.tsx
@@ -29,7 +29,7 @@ import { Rows, Row } from "./layout/rows";
 import { Up } from "../worker/upload_mgr";
 import { UploadEntry, UploadState } from "../worker/interface";
 import { getIcon } from "./visual/icons";
-import { filesViewCtrl } from "../common/controls";
+import { ctrlOn, sharingCtrl, filesViewCtrl } from "../common/controls";
 
 export interface Item {
   name: string;
@@ -559,6 +559,11 @@ export class FilesPanel extends React.Component<Props, State, {}> {
     sortedItems: List<MetadataResp>,
     showOp: string
   ): React.ReactNode => {
+    const shareModeClass =
+      this.props.ui.control.controls.get(sharingCtrl) === ctrlOn
+        ? "hidden"
+        : "";
+
     const sortKeys = List<string>([
       this.props.msg.pkg.get("item.type"),
       this.props.msg.pkg.get("item.name"),
@@ -599,7 +604,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         <div className={`v-mid item-op ${showOp}`}>
           <RiCheckboxFill
             size="1.8rem"
-            className={selectedIconColor}
+            className={`${selectedIconColor} ${shareModeClass}`}
             onClick={() => this.select(item.name)}
           />
         </div>
@@ -613,7 +618,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
 
           <RiCheckboxFill
             size="1.8rem"
-            className={selectedIconColor}
+            className={`${selectedIconColor} ${shareModeClass}`}
             onClick={() => this.select(item.name)}
           />
         </div>
@@ -670,7 +675,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
                   <RiRefreshLine
                     onClick={() => this.generateHash(itemPath)}
                     size={"2rem"}
-                    className="black-font"
+                    className={`black-font ${shareModeClass}`}
                   />,
                 ])}
                 childrenStyles={List([{}, { justifyContent: "flex-end" }])}
@@ -731,6 +736,11 @@ export class FilesPanel extends React.Component<Props, State, {}> {
   };
 
   render() {
+    const shareModeClass =
+      this.props.ui.control.controls.get(sharingCtrl) === ctrlOn
+        ? "hidden"
+        : "";
+
     const showOp = this.props.login.userRole === roleVisitor ? "hidden" : "";
     const breadcrumb = this.props.filesInfo.dirPath.map(
       (pathPart: string, key: number) => {
@@ -920,7 +930,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
               </div>,
               <div
                 id="space-used"
-                className="grey0-font"
+                className={`grey0-font ${shareModeClass}`}
               >{`${this.props.msg.pkg.get(
                 "browser.used"
               )} ${usedSpace} / ${spaceLimit}`}</div>,

--- a/src/client/web/src/components/panel_files.tsx
+++ b/src/client/web/src/components/panel_files.tsx
@@ -428,6 +428,10 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         </div>
       );
 
+      const modTimeTitle = this.props.msg.pkg.get("item.modTime");
+      const sizeTitle = this.props.msg.pkg.get("item.size");
+      const itemSize = FileSize(item.size, { round: 0 });
+
       const content = item.isDir ? (
         <div className={`v-mid item-cell`}>
           <div className="full-width">
@@ -438,7 +442,10 @@ export class FilesPanel extends React.Component<Props, State, {}> {
               {item.name}
             </div>
             <div className="desc-m grey0-font">
-              <span>{item.modTime.slice(0, item.modTime.indexOf("T"))}</span>
+              <span>
+                <span className="grey3-font">{`${modTimeTitle}: `}</span>
+                <span>{`${item.modTime}`}</span>
+              </span>
             </div>
           </div>
         </div>
@@ -454,38 +461,16 @@ export class FilesPanel extends React.Component<Props, State, {}> {
                 {item.name}
               </a>
               <div className="desc-m grey0-font">
-                <span>{item.modTime.slice(0, item.modTime.indexOf("T"))}</span>
-                &nbsp;/&nbsp;
-                <span>{FileSize(item.size, { round: 0 })}</span>
+                <span className="grey3-font">{`${sizeTitle}: `}</span>
+                <span>{`${itemSize} | `}</span>
+                <span className="grey3-font">{`SHA1: `}</span>
+                <span>{item.sha1}</span>
               </div>
             </div>
-          </div>
-
-          <div
-            className={`${
-              this.state.showDetail.has(item.name) ? "" : "hidden"
-            }`}
-          >
-            <Flexbox
-              children={List([
-                <div className="label">{`SHA1: `}</div>,
-                <RiRestartFill
-                  onClick={() => this.generateHash(itemPath)}
-                  size={"2rem"}
-                  className="grey3-font"
-                />,
-              ])}
-              className="item-info"
-              childrenStyles={List([{}, { justifyContent: "flex-end" }])}
-            />
-            <div className="info">{item.sha1}</div>
           </div>
         </div>
       );
 
-      const detailColor = this.state.showDetail.has(item.name)
-        ? "cyan1"
-        : "grey0";
       const op = item.isDir ? (
         <div className={`v-mid item-cell item-op ${showOp}`}>
           <span onClick={() => this.select(item.name)} className="float-l">
@@ -496,13 +481,6 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         </div>
       ) : (
         <div className={`v-mid item-cell item-op ${showOp}`}>
-          <span
-            onClick={() => this.toggleDetail(item.name)}
-            className="float-l"
-          >
-            {getIcon("RiMore2Fill", "1.8rem", detailColor)}
-          </span>
-
           <span onClick={() => this.select(item.name)} className="float-l">
             {isSelected
               ? getIcon("RiCheckboxFill", "1.8rem", "cyan1")
@@ -577,7 +555,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         ? `${dirPath}${item.name}`
         : `${dirPath}/${item.name}`;
 
-      const selectedIconColor = isSelected ? "cyan1-font" : "grey0-font";
+      const selectedIconColor = isSelected ? "cyan1-font" : "black1-font";
 
       const descIconColor = this.state.showDetail.has(item.name)
         ? "cyan1-font"

--- a/src/client/web/src/components/panel_files.tsx
+++ b/src/client/web/src/components/panel_files.tsx
@@ -12,7 +12,8 @@ import { RiCheckboxFill } from "@react-icons/all-files/ri/RiCheckboxFill";
 import { RiMore2Fill } from "@react-icons/all-files/ri/RiMore2Fill";
 import { BiTable } from "@react-icons/all-files/bi/BiTable";
 import { BiListUl } from "@react-icons/all-files/bi/BiListUl";
-import { RiRefreshLine } from "@react-icons/all-files/ri/RiRefreshLine";
+import { RiRestartFill } from "@react-icons/all-files/ri/RiRestartFill";
+import { RiCheckboxBlankLine } from "@react-icons/all-files/ri/RiCheckboxBlankLine";
 
 import { ErrorLogger } from "../common/log_error";
 import { alertMsg, confirmMsg } from "../common/env";
@@ -468,10 +469,10 @@ export class FilesPanel extends React.Component<Props, State, {}> {
             <Flexbox
               children={List([
                 <div className="label">{`SHA1: `}</div>,
-                <RiRefreshLine
+                <RiRestartFill
                   onClick={() => this.generateHash(itemPath)}
                   size={"2rem"}
-                  className="black-font"
+                  className="grey3-font"
                 />,
               ])}
               className="item-info"
@@ -490,7 +491,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
           <span onClick={() => this.select(item.name)} className="float-l">
             {isSelected
               ? getIcon("RiCheckboxFill", "1.8rem", "cyan1")
-              : getIcon("RiCheckboxBlankFill", "1.8rem", "black1")}
+              : getIcon("RiCheckboxBlankLine", "1.8rem", "black1")}
           </span>
         </div>
       ) : (
@@ -505,7 +506,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
           <span onClick={() => this.select(item.name)} className="float-l">
             {isSelected
               ? getIcon("RiCheckboxFill", "1.8rem", "cyan1")
-              : getIcon("RiCheckboxBlankFill", "1.8rem", "black1")}
+              : getIcon("RiCheckboxBlankLine", "1.8rem", "black1")}
           </span>
         </div>
       );
@@ -577,6 +578,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         : `${dirPath}/${item.name}`;
 
       const selectedIconColor = isSelected ? "cyan1-font" : "grey0-font";
+
       const descIconColor = this.state.showDetail.has(item.name)
         ? "cyan1-font"
         : "grey0-font";
@@ -600,14 +602,22 @@ export class FilesPanel extends React.Component<Props, State, {}> {
         </a>
       );
 
+      const checkIcon = isSelected ? (
+        <RiCheckboxFill
+          size="1.8rem"
+          className={`${selectedIconColor} ${shareModeClass}`}
+          onClick={() => this.select(item.name)}
+        />
+      ) : (
+        <RiCheckboxBlankLine
+          size="1.8rem"
+          className={`${selectedIconColor} ${shareModeClass}`}
+          onClick={() => this.select(item.name)}
+        />
+      );
+
       const op = item.isDir ? (
-        <div className={`v-mid item-op ${showOp}`}>
-          <RiCheckboxFill
-            size="1.8rem"
-            className={`${selectedIconColor} ${shareModeClass}`}
-            onClick={() => this.select(item.name)}
-          />
-        </div>
+        <div className={`v-mid item-op ${showOp}`}>{checkIcon}</div>
       ) : (
         <div className={`v-mid item-op ${showOp}`}>
           <RiMore2Fill
@@ -616,11 +626,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
             onClick={() => this.toggleDetail(item.name)}
           />
 
-          <RiCheckboxFill
-            size="1.8rem"
-            className={`${selectedIconColor} ${shareModeClass}`}
-            onClick={() => this.select(item.name)}
-          />
+          {checkIcon}
         </div>
       );
 
@@ -633,13 +639,20 @@ export class FilesPanel extends React.Component<Props, State, {}> {
 
       const compact = item.isDir ? (
         <span>
-          <span className="grey3-font">{`${pathTitle}: `}</span>
-          <span>{`${absDownloadURL} | `}</span>
           <span className="grey3-font">{`${modTimeTitle}: `}</span>
           <span>{item.modTime}</span>
         </span>
       ) : (
-        `${pathTitle}: ${absDownloadURL} | ${modTimeTitle}: ${item.modTime} | ${sizeTitle}: ${itemSize} | sha1: ${item.sha1}`
+        <span>
+          <span className="grey3-font">{`${pathTitle}: `}</span>
+          <span>{`${absDownloadURL} | `}</span>
+          <span className="grey3-font">{`${modTimeTitle}: `}</span>
+          <span>{`${item.modTime} | `}</span>
+          <span className="grey3-font">{`${sizeTitle}: `}</span>
+          <span>{`${itemSize} | `}</span>
+          <span className="grey3-font">{`SHA1: `}</span>
+          <span>{item.sha1}</span>
+        </span>
       );
       const details = (
         <div>
@@ -648,6 +661,9 @@ export class FilesPanel extends React.Component<Props, State, {}> {
               <span className="title-m black-font">{pathTitle}</span>
               <span>{absDownloadURL}</span>
             </div>
+          </div>
+
+          <div className="column">
             <div className="card">
               <span className="title-m black-font">{modTimeTitle}</span>
               <span>{item.modTime}</span>
@@ -658,24 +674,15 @@ export class FilesPanel extends React.Component<Props, State, {}> {
             </div>
           </div>
 
-          <div className="column">
-            <div className="card">
-              <span className="title-m black-font">{pathTitle}</span>
-              <div className="qrcode-flat">
-                <QRCode value={absDownloadURL} size={128} />
-              </div>
-            </div>
-          </div>
-
           <div className="fix">
             <div className="card">
               <Flexbox
                 children={List([
                   <span className="title-m black-font">SHA1</span>,
-                  <RiRefreshLine
+                  <RiRestartFill
                     onClick={() => this.generateHash(itemPath)}
                     size={"2rem"}
-                    className={`black-font ${shareModeClass}`}
+                    className={`grey3-font ${shareModeClass}`}
                   />,
                 ])}
                 childrenStyles={List([{}, { justifyContent: "flex-end" }])}

--- a/src/client/web/src/components/panel_files.tsx
+++ b/src/client/web/src/components/panel_files.tsx
@@ -664,11 +664,11 @@ export class FilesPanel extends React.Component<Props, State, {}> {
           </div>
 
           <div className="column">
-            <div className="card">
+            <div className="card margin-l-m">
               <span className="title-m black-font">{modTimeTitle}</span>
               <span>{item.modTime}</span>
             </div>
-            <div className="card">
+            <div className="card margin-l-m">
               <span className="title-m black-font">{sizeTitle}</span>
               <span>{itemSize}</span>
             </div>

--- a/src/client/web/src/components/panel_sharings.tsx
+++ b/src/client/web/src/components/panel_sharings.tsx
@@ -3,8 +3,7 @@ import { List, Map } from "immutable";
 import QRCode from "react-qr-code";
 
 import { RiShareBoxLine } from "@react-icons/all-files/ri/RiShareBoxLine";
-import { RiFolderSharedFill } from "@react-icons/all-files/ri/RiFolderSharedFill";
-import { RiEmotionSadLine } from "@react-icons/all-files/ri/RiEmotionSadLine";
+import { RiCloudOffFill } from "@react-icons/all-files/ri/RiCloudOffFill";
 
 import { QRCodeIcon } from "./visual/qrcode";
 import { getErrMsg } from "../common/utils";
@@ -137,7 +136,7 @@ export class SharingsPanel extends React.Component<Props, State, {}> {
       <Container>
         <Flexbox
           children={List([
-            <RiEmotionSadLine size="4rem" className="margin-r-m red0-font" />,
+            <RiCloudOffFill size="4rem" className="margin-r-m red0-font" />,
             <span>
               <h3 className="title-l">
                 {this.props.msg.pkg.get("share.404.title")}

--- a/src/client/web/src/components/panel_sharings.tsx
+++ b/src/client/web/src/components/panel_sharings.tsx
@@ -81,7 +81,7 @@ export class SharingsPanel extends React.Component<Props, State, {}> {
                     this.deleteSharing(dirPath);
                   }}
                 >
-                  {this.props.msg.pkg.get("browser.delete")}
+                  {this.props.msg.pkg.get("op.cancel")}
                 </button>,
               ])}
               childrenStyles={List([

--- a/src/client/web/src/components/panel_sharings.tsx
+++ b/src/client/web/src/components/panel_sharings.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { List } from "immutable";
+import { List, Map } from "immutable";
 import QRCode from "react-qr-code";
 
 import { RiShareBoxLine } from "@react-icons/all-files/ri/RiShareBoxLine";
@@ -17,7 +17,7 @@ import { Container } from "./layout/container";
 import { Rows, Row } from "./layout/rows";
 
 export interface SharingsProps {
-  sharings: List<string>;
+  sharings: Map<string, string>;
 }
 
 export interface Props {
@@ -59,11 +59,12 @@ export class SharingsPanel extends React.Component<Props, State, {}> {
     this.props.update(updater().updateSharingsInfo);
   };
 
-  makeRows = (sharings: List<string>): List<Row> => {
-    const sharingRows = sharings.map((dirPath: string) => {
+  makeRows = (sharings: Map<string, string>): List<Row> => {
+    const sharingRows = sharings.keySeq().map((dirPath: string) => {
+      const shareID = sharings.get(dirPath);
       const sharingURL = `${
         document.location.href.split("?")[0]
-      }?dir=${encodeURIComponent(dirPath)}`;
+      }?sh=${shareID}`;
 
       const row1 = (
         <div>
@@ -109,11 +110,16 @@ export class SharingsPanel extends React.Component<Props, State, {}> {
       };
     });
 
-    return sharingRows;
+    return sharingRows.toList();
   };
 
   updateSharings = (sharings: List<Object>) => {
-    const newSharings = sharings as List<string>;
+    const newSharingDirs = sharings as List<string>;
+    let newSharings = Map<string, string>();
+    newSharingDirs.forEach((dirPath) => {
+      const shareID = this.props.sharingsInfo.sharings.get(dirPath);
+      newSharings = newSharings.set(dirPath, shareID);
+    });
     updater().updateSharings(newSharings);
     this.props.update(updater().updateSharingsInfo);
   };

--- a/src/client/web/src/components/panel_uploadings.tsx
+++ b/src/client/web/src/components/panel_uploadings.tsx
@@ -4,7 +4,7 @@ import FileSize from "filesize";
 
 import { RiUploadCloudFill } from "@react-icons/all-files/ri/RiUploadCloudFill";
 import { RiUploadCloudLine } from "@react-icons/all-files/ri/RiUploadCloudLine";
-import { RiEmotionSadLine } from "@react-icons/all-files/ri/RiEmotionSadLine";
+import { RiCloudOffFill } from "@react-icons/all-files/ri/RiCloudOffFill";
 
 import { alertMsg } from "../common/env";
 import { getErrMsg } from "../common/utils";
@@ -165,7 +165,7 @@ export class UploadingsPanel extends React.Component<Props, State, {}> {
       <Container>
         <Flexbox
           children={List([
-            <RiEmotionSadLine size="4rem" className="margin-r-m red0-font" />,
+            <RiCloudOffFill size="4rem" className="margin-r-m red0-font" />,
             <span>
               <h3 className="title-l">
                 {this.props.msg.pkg.get("upload.404.title")}

--- a/src/client/web/src/components/state_updater.ts
+++ b/src/client/web/src/components/state_updater.ts
@@ -123,12 +123,18 @@ export class Updater {
   };
 
   listSharings = async (): Promise<string> => {
-    const resp = await this.filesClient.listSharings();
-    this.props.sharingsInfo.sharings =
-      resp.status === 200
-        ? List<string>(resp.data.sharingDirs)
-        : this.props.sharingsInfo.sharings;
-    return resp.status === 200 ? "" : errServer;
+    const resp = await this.filesClient.listSharingIDs();
+    if (resp.status !== 200) {
+      return errServer;
+    }
+
+    // transform from built-in map to immutable map
+    let sharings = Map<string, string>();
+    resp.data.IDs.forEach((shareID: string, dirPath: string) => {
+      sharings = sharings.set(dirPath, shareID);
+    });
+    this.props.sharingsInfo.sharings = sharings;
+    return "";
   };
 
   // this function gets information from server and merge them with local information
@@ -271,7 +277,7 @@ export class Updater {
     this.props.uploadingsInfo.uploadings = uploadings;
   };
 
-  updateSharings = (sharings: List<string>) => {
+  updateSharings = (sharings: Map<string, string>) => {
     this.props.sharingsInfo.sharings = sharings;
   };
 

--- a/src/client/web/src/components/visual/icons.tsx
+++ b/src/client/web/src/components/visual/icons.tsx
@@ -18,6 +18,7 @@ import { RiArrowUpDownFill } from "@react-icons/all-files/ri/RiArrowUpDownFill";
 import { BiTable } from "@react-icons/all-files/bi/BiTable";
 import { BiListUl } from "@react-icons/all-files/bi/BiListUl";
 import { RiMore2Fill } from "@react-icons/all-files/ri/RiMore2Fill";
+import { RiCheckboxBlankLine } from "@react-icons/all-files/ri/RiCheckboxBlankLine";
 
 import { colorClass } from "./colors";
 
@@ -44,6 +45,7 @@ const icons = Map<string, IconType>({
   BiTable: BiTable,
   BiListUl: BiListUl,
   RiMore2Fill: RiMore2Fill,
+  RiCheckboxBlankLine: RiCheckboxBlankLine,
 });
 
 export function getIconWithProps(

--- a/src/client/web/src/i18n/en_US.ts
+++ b/src/client/web/src/i18n/en_US.ts
@@ -130,6 +130,7 @@ export const msgs: Map<string, string> = Map({
   "error.report.title": "Error Report",
   "op.truncate": "Truncate",
   "op.submit": "Submit",
+  "op.cancel": "Cancel",
   "term.time": "Time",
   "breadcrumb.loc": "Location",
 });

--- a/src/client/web/src/i18n/zh_CN.ts
+++ b/src/client/web/src/i18n/zh_CN.ts
@@ -127,6 +127,7 @@ export const msgs: Map<string, string> = Map({
   "error.report.title": "报告错误",
   "op.truncate": "清空",
   "op.submit": "提交",
+  "op.cancel": "取消",
   "term.time": "时间",
   "breadcrumb.loc": "位置",
 });

--- a/src/handlers/multiusers/handlers.go
+++ b/src/handlers/multiusers/handlers.go
@@ -73,6 +73,8 @@ func NewMultiUsersSvc(cfg gocfg.ICfg, deps *depidx.Deps) (*MultiUsersSvc, error)
 		apiRuleCname(userstore.AdminRole, "DELETE", "/v1/fs/sharings"):        true,
 		apiRuleCname(userstore.AdminRole, "GET", "/v1/fs/sharings"):           true,
 		apiRuleCname(userstore.AdminRole, "GET", "/v1/fs/sharings/exist"):     true,
+		apiRuleCname(userstore.AdminRole, "GET", "/v1/fs/sharings/dirs"):      true,
+		apiRuleCname(userstore.AdminRole, "GET", "/v1/fs/sharings/ids"):       true,
 		apiRuleCname(userstore.AdminRole, "POST", "/v1/fs/hashes/sha1"):       true,
 		// user rules
 		apiRuleCname(userstore.UserRole, "GET", "/"):                       true,
@@ -105,7 +107,9 @@ func NewMultiUsersSvc(cfg gocfg.ICfg, deps *depidx.Deps) (*MultiUsersSvc, error)
 		apiRuleCname(userstore.UserRole, "DELETE", "/v1/fs/sharings"):      true,
 		apiRuleCname(userstore.UserRole, "GET", "/v1/fs/sharings"):         true,
 		apiRuleCname(userstore.UserRole, "GET", "/v1/fs/sharings/exist"):   true,
-		apiRuleCname(userstore.AdminRole, "POST", "/v1/fs/hashes/sha1"):    true,
+		apiRuleCname(userstore.UserRole, "GET", "/v1/fs/sharings/dirs"):    true,
+		apiRuleCname(userstore.UserRole, "GET", "/v1/fs/sharings/ids"):     true,
+		apiRuleCname(userstore.UserRole, "POST", "/v1/fs/hashes/sha1"):     true,
 		// visitor rules
 		apiRuleCname(userstore.VisitorRole, "GET", "/"):                       true,
 		apiRuleCname(userstore.VisitorRole, "GET", publicPath):                true,
@@ -120,6 +124,7 @@ func NewMultiUsersSvc(cfg gocfg.ICfg, deps *depidx.Deps) (*MultiUsersSvc, error)
 		apiRuleCname(userstore.VisitorRole, "GET", "/v1/captchas/"):           true,
 		apiRuleCname(userstore.VisitorRole, "GET", "/v1/captchas/imgs"):       true,
 		apiRuleCname(userstore.VisitorRole, "GET", "/v1/fs/sharings/exist"):   true,
+		apiRuleCname(userstore.VisitorRole, "GET", "/v1/fs/sharings/dirs"):    true,
 	}
 
 	return &MultiUsersSvc{

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -293,7 +293,9 @@ func initHandlers(router *gin.Engine, cfg gocfg.ICfg, deps *depidx.Deps) (*gin.E
 	filesAPI.POST("/sharings", fileHdrs.AddSharing)
 	filesAPI.DELETE("/sharings", fileHdrs.DelSharing)
 	filesAPI.GET("/sharings", fileHdrs.ListSharings)
+	filesAPI.GET("/sharings/ids", fileHdrs.ListSharingIDs)
 	filesAPI.GET("/sharings/exist", fileHdrs.IsSharing)
+	filesAPI.GET("/sharings/dirs", fileHdrs.GetSharingDir)
 
 	filesAPI.GET("/metadata", fileHdrs.Metadata)
 


### PR DESCRIPTION
Please answer following questions before creating the PR:

* What is this PR about?
  - add shareID in file info
  - enable db schema migration for file info store
  - add APIs for shorten URLs
  - enable shorten URLs in FE
  - replace some icons
  - some small fixes
* Is there any test which covers the change?
  - e2e tests
  - unit tests
