### PR TITLE
fix(uploader): refreshing files list after uploading status changing always returns error

### DIFF
--- a/src/client/web/src/components/panel_files.tsx
+++ b/src/client/web/src/components/panel_files.tsx
@@ -138,8 +138,7 @@ export class FilesPanel extends React.Component<Props, State, {}> {
   };
 
   updateProgress = async (
-    infos: Map<string, UploadEntry>,
-    refresh: boolean
+    infos: Map<string, UploadEntry>
   ) => {
     updater().setUploads(infos);
     let errCount = 0;
@@ -157,16 +156,6 @@ export class FilesPanel extends React.Component<Props, State, {}> {
       this.props.update(updater().updateLogin);
       this.props.update(updater().updateUploadingsInfo);
     }
-
-    if (refresh) {
-      const status = await updater().setItems(this.props.filesInfo.dirPath);
-      if (status !== "") {
-        alertMsg(getErrMsg(this.props.msg.pkg, "op.fail", status));
-        return;
-      }
-    }
-    this.props.update(updater().updateFilesInfo);
-    this.props.update(updater().updateUploadingsInfo);
   };
 
   addUploads = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/client/web/src/worker/upload_mgr.ts
+++ b/src/client/web/src/worker/upload_mgr.ts
@@ -26,9 +26,8 @@ export class UploadMgr {
   private worker: IWorker;
   private infos = OrderedMap<string, UploadEntry>();
   private statusCb = (
-    infos: Map<string, UploadEntry>,
-    refresh: boolean
-  ): void => {};
+    infos: Map<string, UploadEntry>
+  ): void => { };
 
   constructor(worker: IWorker) {
     this.worker = worker;
@@ -104,7 +103,7 @@ export class UploadMgr {
   // TODO: change it to observer pattern
   // so that it can be observed by multiple components
   setStatusCb = (
-    cb: (infos: Map<string, UploadEntry>, refresh: boolean) => void
+    cb: (infos: Map<string, UploadEntry>) => void
   ) => {
     this.statusCb = cb;
   };
@@ -156,7 +155,7 @@ export class UploadMgr {
       }
     }
 
-    this.statusCb(this.infos.toMap(), false);
+    this.statusCb(this.infos.toMap());
     return status;
   };
 
@@ -173,7 +172,7 @@ export class UploadMgr {
       status = errUploadMgr;
     }
 
-    this.statusCb(this.infos.toMap(), false);
+    this.statusCb(this.infos.toMap());
     return status;
   };
 
@@ -184,7 +183,7 @@ export class UploadMgr {
     }
 
     this.infos = this.infos.delete(filePath);
-    this.statusCb(this.infos.toMap(), false);
+    this.statusCb(this.infos.toMap());
     return "";
   };
 
@@ -213,7 +212,7 @@ export class UploadMgr {
           ErrorLogger().error(`respHandler: entry not found ${errResp.err}`);
         }
 
-        this.statusCb(this.infos.toMap(), false);
+        this.statusCb(this.infos.toMap());
         break;
       case uploadInfoKind:
         const infoResp = resp as UploadInfoResp;
@@ -222,12 +221,12 @@ export class UploadMgr {
         if (entry != null) {
           if (infoResp.uploaded === entry.size) {
             this.infos = this.infos.delete(infoResp.filePath);
-            this.statusCb(this.infos.toMap(), true);
+            this.statusCb(this.infos.toMap());
           } else {
             // this avoids overwriting Stopped/Error state
             const state =
               entry.state === UploadState.Stopped ||
-              entry.state === UploadState.Error
+                entry.state === UploadState.Error
                 ? entry.state
                 : infoResp.state;
             this.infos = this.infos.set(infoResp.filePath, {
@@ -235,7 +234,7 @@ export class UploadMgr {
               uploaded: infoResp.uploaded,
               state: state,
             });
-            this.statusCb(this.infos.toMap(), false);
+            this.statusCb(this.infos.toMap());
           }
         } else {
           ErrorLogger().error(


### PR DESCRIPTION
Please answer following questions before creating the PR:

* What is this PR about?
  - fix: don't need to refresh in uploading status changes and it always returns error
* Is there any test which covers the change?
  - unit tests
